### PR TITLE
[Bugfix] fixes #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.5
+
+* [Fixed] Bug #1 
+* removed code duplication
+
 ## 0.0.4
 
 * Downgrade `test` to `^1.16.0`

--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ given('Post Controller', body: () {
 
 * Collision with [mocktail](https://pub.dev/packages/mocktail) or [mockito](https://pub.dev/packages/mockito) packages which bring `where` method too, you can hide `when` and use `whenn` of this package like below
 
+But prefere to hide and rename imports like so.
+
+```dart 
+import 'package:mocktail/mocktail.dart' hide when;
+import 'package:mocktail/mocktail.dart' as mktl show when;
+```
+
 ```dart
 import 'package:given_when_then_unit_test/given_when_then_unit_test.dart' hide when;
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -98,7 +98,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.4"
   glob:
     dependency: transitive
     description:

--- a/lib/res/given.dart
+++ b/lib/res/given.dart
@@ -62,6 +62,8 @@ void given(
   dynamic Function()? after,
   bool skip = false,
 }) {
+  if(body is Future Function()) throw ArgumentError('body may not be async.');
+
   final regExp = RegExp(r'^\[\w+]');
   final w = regExp.stringMatch(description);
 

--- a/lib/res/when.dart
+++ b/lib/res/when.dart
@@ -55,14 +55,15 @@ import 'package:test/test.dart';
 /// avoid this flag if possible, and instead use the test runner flag `-n` to
 /// filter tests by name.
 @isTestGroup
-void when2(
+void when(
   String description,
-  dynamic Function()? before, {
-  required dynamic Function() then,
-  // dynamic Function()? before,
+  dynamic Function() body, {
+  dynamic Function()? before,
   dynamic Function()? after,
   bool skip = false,
 }) {
+  if(body is Future Function()) throw ArgumentError('when body may not be async.');
+
   final regExp = RegExp(r'^\[\w+]');
   final w = regExp.stringMatch(description);
 
@@ -79,172 +80,31 @@ void when2(
     () {
       setUp(() => before?.call());
       tearDown(() => after?.call());
-      then();
+      body();
     },
     skip: skip,
   );
 }
 
-/// Creates a group of tests.
-///
-/// A group's description (converted to a string) is included in the descriptions
-/// of any tests or sub-groups it contains. [setUp] and [tearDown] are also scoped
-/// to the containing group.
-///
-/// If [testOn] is passed, it's parsed as a [platform selector][]; the test will
-/// only be run on matching platforms.
-///
-/// [platform selector]: https://github.com/dart-lang/test/tree/master/pkgs/test#platform-selectors
-///
-/// If [timeout] is passed, it's used to modify or replace the default timeout
-/// of 30 seconds. Timeout modifications take precedence in suite-group-test
-/// order, so [timeout] will also modify any timeouts set on the suite, and will
-/// be modified by any timeouts set on individual tests.
-///
-/// If [skip] is a String or `true`, the group is skipped. If it's a String, it
-/// should explain why the group is skipped; this reason will be printed instead
-/// of running the group's tests.
-///
-/// If [tags] is passed, it declares user-defined tags that are applied to the
-/// test. These tags can be used to select or skip the test on the command line,
-/// or to do bulk test configuration. All tags should be declared in the
-/// [package configuration file][configuring tags]. The parameter can be an
-/// [Iterable] of tag names, or a [String] representing a single tag.
-///
-/// [configuring tags]: https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#configuring-tags
-///
-/// [onPlatform] allows groups to be configured on a platform-by-platform
-/// basis. It's a map from strings that are parsed as [PlatformSelector]s to
-/// annotation classes: [Timeout], [Skip], or lists of those. These
-/// annotations apply only on the given platforms. For example:
-///
-///     group('potentially slow tests', () {
-///       // ...
-///     }, onPlatform: {
-///       // These tests are especially slow on Windows.
-///       'windows': Timeout.factor(2),
-///       'browser': [
-///         Skip('TODO: add browser support'),
-///         // They'll be slow on browsers once it works on them.
-///         Timeout.factor(2)
-///       ]
-///     });
-///
-/// If multiple platforms match, the annotations apply in order as through
-/// they were in nested groups.
-///
-/// If the `solo` flag is `true`, only tests and groups marked as
-/// "solo" will be be run. This only restricts tests *within this test
-/// suite*—tests in other suites will run as normal. We recommend that users
-/// avoid this flag if possible, and instead use the test runner flag `-n` to
-/// filter tests by name.
+/// Alias for [when]; with slight alterations in the signature
+/// 
+/// see [when] for the documentation
 @isTestGroup
 void whenn(
   String description,
   dynamic Function() body, {
   dynamic Function()? after,
   bool skip = false,
-}) {
-  final regExp = RegExp(r'^\[\w+]');
-  final w = regExp.stringMatch(description);
+}) => when(description, body, after: after, skip: skip);
 
-  var desc = description;
-  var beggining = 'When ';
-
-  if (w != null && w != '') {
-    desc = description.replaceAll(w, '');
-    beggining = w.replaceAll('[', '').replaceAll(']', '');
-  }
-
-  group(
-    '$beggining$desc',
-    () {
-      // setUp(() => before?.call());
-      tearDown(() => after?.call());
-      body();
-    },
-    skip: skip,
-  );
-}
-
-/// Creates a group of tests.
-///
-/// A group's description (converted to a string) is included in the descriptions
-/// of any tests or sub-groups it contains. [setUp] and [tearDown] are also scoped
-/// to the containing group.
-///
-/// If [testOn] is passed, it's parsed as a [platform selector][]; the test will
-/// only be run on matching platforms.
-///
-/// [platform selector]: https://github.com/dart-lang/test/tree/master/pkgs/test#platform-selectors
-///
-/// If [timeout] is passed, it's used to modify or replace the default timeout
-/// of 30 seconds. Timeout modifications take precedence in suite-group-test
-/// order, so [timeout] will also modify any timeouts set on the suite, and will
-/// be modified by any timeouts set on individual tests.
-///
-/// If [skip] is a String or `true`, the group is skipped. If it's a String, it
-/// should explain why the group is skipped; this reason will be printed instead
-/// of running the group's tests.
-///
-/// If [tags] is passed, it declares user-defined tags that are applied to the
-/// test. These tags can be used to select or skip the test on the command line,
-/// or to do bulk test configuration. All tags should be declared in the
-/// [package configuration file][configuring tags]. The parameter can be an
-/// [Iterable] of tag names, or a [String] representing a single tag.
-///
-/// [configuring tags]: https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#configuring-tags
-///
-/// [onPlatform] allows groups to be configured on a platform-by-platform
-/// basis. It's a map from strings that are parsed as [PlatformSelector]s to
-/// annotation classes: [Timeout], [Skip], or lists of those. These
-/// annotations apply only on the given platforms. For example:
-///
-///     group('potentially slow tests', () {
-///       // ...
-///     }, onPlatform: {
-///       // These tests are especially slow on Windows.
-///       'windows': Timeout.factor(2),
-///       'browser': [
-///         Skip('TODO: add browser support'),
-///         // They'll be slow on browsers once it works on them.
-///         Timeout.factor(2)
-///       ]
-///     });
-///
-/// If multiple platforms match, the annotations apply in order as through
-/// they were in nested groups.
-///
-/// If the `solo` flag is `true`, only tests and groups marked as
-/// "solo" will be be run. This only restricts tests *within this test
-/// suite*—tests in other suites will run as normal. We recommend that users
-/// avoid this flag if possible, and instead use the test runner flag `-n` to
-/// filter tests by name.
+/// Alias for [when]; with slight alterations in the signature
+/// 
+/// see [when] for the documentation
 @isTestGroup
-void when(
+void when2(
   String description,
-  dynamic Function() body, {
+  dynamic Function()? before, {
+  required dynamic Function() then,
   dynamic Function()? after,
   bool skip = false,
-}) {
-  final regExp = RegExp(r'^\[\w+]');
-  final w = regExp.stringMatch(description);
-
-  var desc = description;
-  var beggining = 'When ';
-
-  if (w != null && w != '') {
-    desc = description.replaceAll(w, '');
-    beggining = w.replaceAll('[', '').replaceAll(']', '');
-  }
-
-  group(
-    '$beggining$desc',
-    () {
-      // setUp(() => before?.call());
-      tearDown(() => after?.call());
-      body();
-    },
-    skip: skip,
-  );
-}
+}) => when(description, then, before: before, after: after, skip: skip);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: given_when_then_unit_test
 description: A package to make Unit Test code more readable and well documented.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/AndrewPiterov/given_when_then_unit_test
 
 environment:

--- a/test/calculator_test.dart
+++ b/test/calculator_test.dart
@@ -11,7 +11,7 @@ void main() {
   });
 
   afterAll(() {
-    print('... all tests has been fiished.');
+    print('... all tests has been finished.');
   });
 
   given('empty calculator', () {

--- a/test/unittest/group_test.dart
+++ b/test/unittest/group_test.dart
@@ -1,0 +1,59 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:given_when_then_unit_test/given_when_then_unit_test.dart';
+import 'package:test/expect.dart';
+// ignore: depend_on_referenced_packages bcs it is needed to run a test calls like (when, given) inside a test without registering them
+import 'package:test_api/src/backend/declarer.dart';
+import 'package:test_api/src/backend/group_entry.dart';
+
+/// Given and when both delegate to [group].
+/// 
+/// see issue #1
+void main() {
+  given('async body of Future<null>', () => _testFunctions(_asyncFunc));
+
+  given('async body of Future<int>', () => _testFunctions(_asyncFuncInt));
+}
+
+void _testFunctions(dynamic Function() body){
+  then('"given" should throw', () {
+      declare(() {
+        expect(() => given('', body), throwsArgumentError);
+      });
+    });
+
+    then('"when" shall throw', (){
+      declare(() {
+        expect(() => when('', body), throwsArgumentError);
+      });
+    });
+    then('"whenn" shall throw', (){
+      declare(() {
+        expect(() => whenn('', body), throwsArgumentError);
+      });
+    });
+    then('"when2" shall throw', (){
+      declare(() {
+        expect(() => when2('', (){}, then: body), throwsArgumentError);
+      });
+    });
+}
+
+
+/// Runs [body] with a declarer and returns the declared entries.
+/// 
+/// For ref [see](https://github.com/dart-lang/test/blob/767dbb5888ab5376ef0319006f7c90b028c1dbf8/pkgs/test_api/test/utils.dart#L173)
+List<GroupEntry> declare(void Function() body) {
+  final declarer = Declarer()..declare(body);
+  return declarer.build().entries;
+}
+
+
+Future _asyncFunc() async {
+  await Future.delayed(const Duration(seconds: 1));
+}
+
+Future<int> _asyncFuncInt() async {
+   await Future.delayed(const Duration(seconds: 1));
+   return 1;
+}


### PR DESCRIPTION
- Fixes the bug as described in #1
  TL;DR: the test construct group dosnt allow for async bodys.
   given and when both hid the asyncness of body. Leading to unexpected behaviour
    and crashes
- Removed codeduplication from when.dart . All when* methods where
  identical.
- Added a test to catch the behaviour leading to the described bug

Amending: version upgrade in pubspec.yamAmending: version upgrade in pubspec.yaml